### PR TITLE
Allow using unsafe directory in container

### DIFF
--- a/ansible-docker.sh
+++ b/ansible-docker.sh
@@ -62,6 +62,8 @@ ansible::test::playbook() {
   ansible-playbook --connection=local --inventory host.ini ${TARGETS} 
 }
 
+# avoid git complaining about directory owned by somebody else in the container
+git config --global --add safe.directory /github/workspace
 # make sure git is up to date
 git submodule update --init --recursive
 if [[ "${REQUIREMENTS}" == *.yml ]]


### PR DESCRIPTION
From yesterday, I am getting failures like:
```
+ git submodule update --init --recursive
fatal: unsafe repository ('/github/workspace' is owned by someone else)
To add an exception for this directory, call:

	git config --global --add safe.directory /github/workspace
```
Hopefully, this setting will solve the issue. I am frankly not sure why it popped up right yesterday as the Ubuntu git is still older than anything we have in Fedora so I will assume some bad version or configuration popped up from somewhere.