### PR TITLE
fix: Ubuntu 24.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,8 @@ RUN apt-get update -y && apt-get install -y \
     python3-dev \
     python3-pip \
     git \
-    systemd
-
-RUN pip3 install setuptools && pip3 install ansible
+    systemd \
+    ansible
 
 RUN ansible --version
 


### PR DESCRIPTION
Install ansible from APT. pipx install ansible resulted in only ansible-community in /root/.local.bin.  This should resolve the issue with this action for the time being, pending a longer term solution is latest Ansible is intended.